### PR TITLE
Handle cancellation errors in stop_recording

### DIFF
--- a/recorder.py
+++ b/recorder.py
@@ -127,6 +127,9 @@ class RecorderManager:
                 rec.proc.kill()
             except Exception:
                 pass
+        except asyncio.CancelledError:
+            # La tarea fue cancelada con éxito; el waiter se encarga de limpiar el proceso
+            pass
         return True
 
     async def record_clip(self, url: str, model_name: str, duration: int = CLIP_DURATION) -> Path:


### PR DESCRIPTION
## Summary
- handle `asyncio.CancelledError` in `stop_recording` to prevent propagation when stopping a recording

## Testing
- `python -m py_compile recorder.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60c2ff23083328625e901f2de6c6d