### PR TITLE
Add modular skeleton for Telegram media bot

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,0 +1,100 @@
+"""Command handlers for the Telegram bot.
+
+Each command validates user authorization and enqueues tasks for workers. The
+actual business logic is expected to live in other modules (``upload``,
+``ingest``, ``processing``...).
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from telethon import events, TelegramClient
+
+from config import AUTHORIZED_USERS
+from task_queue import TaskQueue, Task
+
+__all__ = ["register_handlers"]
+
+async def _is_authorized(event: events.NewMessage.Event) -> bool:
+    """Check whether the sender of *event* is authorized."""
+    sender = await event.get_sender()
+    return bool(sender and getattr(sender, "id", None) in AUTHORIZED_USERS)
+
+def register_handlers(client: TelegramClient, queue: TaskQueue) -> None:
+    """Register all command handlers on the given *client*."""
+
+    @client.on(events.NewMessage(pattern="/upload"))
+    async def cmd_upload(event: events.NewMessage.Event) -> None:
+        """Upload local files with auto splitting."""
+        if not await _is_authorized(event):
+            await event.reply("❌ No autorizado")
+            return
+        await event.reply("📝 Subida en cola (función aún no implementada)")
+
+    @client.on(events.NewMessage(pattern=r"/ingest\s+(.+)"))
+    async def cmd_ingest(event: events.NewMessage.Event) -> None:
+        """Download media from a URL using yt-dlp."""
+        if not await _is_authorized(event):
+            await event.reply("❌ No autorizado")
+            return
+        await event.reply("📥 Descarga en cola (función aún no implementada)")
+
+    @client.on(events.NewMessage(pattern=r"/clip\s+([0-9:]+-[0-9:]+)"))
+    async def cmd_clip(event: events.NewMessage.Event) -> None:
+        """Generate a clip from a file or URL."""
+        if not await _is_authorized(event):
+            await event.reply("❌ No autorizado")
+            return
+        await event.reply("✂️ Clip solicitado (función aún no implementada)")
+
+    @client.on(events.NewMessage(pattern=r"/record\s+(.+)"))
+    async def cmd_record(event: events.NewMessage.Event) -> None:
+        """Record a live stream."""
+        if not await _is_authorized(event):
+            await event.reply("❌ No autorizado")
+            return
+        await event.reply("⏺️ Grabación en cola (función aún no implementada)")
+
+    @client.on(events.NewMessage(pattern=r"/monitor\s+(.+)"))
+    async def cmd_monitor(event: events.NewMessage.Event) -> None:
+        """Monitor a stream and record automatically when online."""
+        if not await _is_authorized(event):
+            await event.reply("❌ No autorizado")
+            return
+        await event.reply("👀 Monitor en cola (función aún no implementada)")
+
+    @client.on(events.NewMessage(pattern="/queue"))
+    async def cmd_queue(event: events.NewMessage.Event) -> None:
+        """List queued tasks."""
+        if not await _is_authorized(event):
+            await event.reply("❌ No autorizado")
+            return
+        tasks = "\n".join(t.task_id for t in queue._queue) or "(vacío)"
+        await event.reply(f"📋 Tareas en cola:\n{tasks}")
+
+    @client.on(events.NewMessage(pattern="/settings"))
+    async def cmd_settings(event: events.NewMessage.Event) -> None:
+        """Change runtime settings like quality or proxy."""
+        if not await _is_authorized(event):
+            await event.reply("❌ No autorizado")
+            return
+        await event.reply("⚙️ Configuración no implementada")
+
+    @client.on(events.NewMessage(pattern="/help"))
+    async def cmd_help(event: events.NewMessage.Event) -> None:
+        """Provide contextual help."""
+        if not await _is_authorized(event):
+            await event.reply("❌ No autorizado")
+            return
+        await event.reply(
+            """Comandos disponibles:
+/upload - Subir archivos
+/ingest <URL> - Descargar media
+/clip HH:MM:SS-HH:MM:SS - Crear clip
+/record <URL|canal> - Grabar stream
+/monitor <URL|canal> - Vigilar y grabar
+/queue - Ver tareas pendientes
+/settings - Ajustes
+/help - Esta ayuda
+"""
+        )

--- a/config.py
+++ b/config.py
@@ -1,16 +1,42 @@
-# config.py
-# -------------------------
-# Rellena estos valores antes de ejecutar
+"""Global configuration for the bot.
 
-TELEGRAM_API_ID = 1234567           # tu API ID en my.telegram.org
-TELEGRAM_API_HASH = "tu_api_hash"   # tu API Hash
-BOT_TOKEN = "tu_bot_token"          # token del bot (BotFather)
-AUTHORIZED_USERS = {123456789}      # IDs permitidos a usar el bot (enteros)
+Values are stored in the :class:`BotConfig` dataclass for easy access and can be
+customised before running the application. Module level constants are provided
+for backward compatibility with existing modules.
+"""
+from __future__ import annotations
 
-OUTPUT_DIR = "recordings"           # carpeta donde se guardan los videos
-CLIP_DURATION = 30                  # segundos para clips
-MONITOR_POLL_INTERVAL = 60          # segundos entre comprobaciones del estado (monitor)
-YTDLP_PATH = "yt-dlp"               # comando de yt-dlp (ajusta si usas ruta completa)
-FFMPEG_PATH = "ffmpeg"              # comando de ffmpeg (ajusta si usas ruta completa)
+from dataclasses import dataclass, field
+from typing import Set
 
-LOG_LEVEL = "INFO"                  # DEBUG | INFO | WARNING | ERROR
+@dataclass
+class BotConfig:
+    TELEGRAM_API_ID: int = 1234567
+    TELEGRAM_API_HASH: str = "tu_api_hash"
+    BOT_TOKEN: str = "tu_bot_token"
+    AUTHORIZED_USERS: Set[int] = field(default_factory=lambda: {123456789})
+
+    OUTPUT_DIR: str = "recordings"
+    CLIP_DURATION: int = 30
+    MONITOR_POLL_INTERVAL: int = 60
+    YTDLP_PATH: str = "yt-dlp"
+    FFMPEG_PATH: str = "ffmpeg"
+
+    LOG_LEVEL: str = "INFO"  # DEBUG | INFO | WARNING | ERROR
+    NORMAL_UPLOAD_LIMIT_GB: int = 2
+    PREMIUM_UPLOAD_LIMIT_GB: int = 4
+
+# Default configuration instance used by the application
+config = BotConfig()
+
+# Expose legacy constants for modules that import them directly
+TELEGRAM_API_ID = config.TELEGRAM_API_ID
+TELEGRAM_API_HASH = config.TELEGRAM_API_HASH
+BOT_TOKEN = config.BOT_TOKEN
+AUTHORIZED_USERS = config.AUTHORIZED_USERS
+OUTPUT_DIR = config.OUTPUT_DIR
+CLIP_DURATION = config.CLIP_DURATION
+MONITOR_POLL_INTERVAL = config.MONITOR_POLL_INTERVAL
+YTDLP_PATH = config.YTDLP_PATH
+FFMPEG_PATH = config.FFMPEG_PATH
+LOG_LEVEL = config.LOG_LEVEL

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,14 @@
+"""Test configuration ensuring repository root on ``sys.path``.
+
+Pytest does not always include the project root in ``sys.path`` when executed in
+certain environments. This file guarantees that modules like ``recorder`` can be
+imported during tests.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/fs_utils.py
+++ b/fs_utils.py
@@ -1,0 +1,27 @@
+"""Utilities for filesystem operations.
+
+This module centralizes all file-related helpers like path sanitization and
+directory creation. It aims to keep all file system interactions safe and
+portable across platforms.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+__all__ = ["sanitize_filename", "ensure_directory"]
+
+# Regex that matches any character not allowed in safe filenames.
+_SANITIZE_RE = re.compile(r"[^-_.() a-zA-Z0-9]")
+
+def sanitize_filename(name: str) -> str:
+    """Return a filesystem-safe version of *name*.
+
+    This function removes characters that may be unsafe or unsupported on
+    various filesystems. It does not attempt to handle reserved names.
+    """
+    return _SANITIZE_RE.sub("_", name)
+
+def ensure_directory(path: Path) -> None:
+    """Create *path* if it doesn't exist."""
+    path.mkdir(parents=True, exist_ok=True)

--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,25 @@
+"""Media ingestion helpers using yt-dlp.
+
+The real implementation should download external resources and validate that the
+resulting file matches expected codecs/containers before handing it over for
+further processing.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+from config import YTDLP_PATH
+
+__all__ = ["download"]
+
+async def download(url: str, output: Path, fmt: Optional[str] = None) -> Path:
+    """Download *url* into *output* and return the resulting path.
+
+    ``fmt`` can be used to force a specific yt-dlp format selection. The
+    function should raise an exception if the download fails or the file does not
+    comply with validation rules.
+    """
+    # TODO: implement download via yt-dlp with validations
+    raise NotImplementedError

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,38 @@
+"""Logging configuration for the bot.
+
+The project uses structured JSON logging to simplify parsing and aggregation of
+logs. Use :func:`configure_logging` at the entry point to enable it.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from typing import Any, Dict
+
+__all__ = ["configure_logging"]
+
+class JsonFormatter(logging.Formatter):
+    """Minimal JSON formatter for logging records."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting logic
+        data: Dict[str, Any] = {
+            "time": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            data["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(data, ensure_ascii=False)
+
+def configure_logging(level: int | None = None) -> None:
+    """Configure root logger to output JSON lines."""
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    if level is None:
+        level = logging.INFO
+    root.setLevel(level)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,51 @@
+"""Entrypoint for the Telegram bot.
+
+It bootstraps the Telethon client, initializes the task queue and launches
+worker tasks responsible for ingesting, processing and uploading media.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+from telethon import TelegramClient
+
+from config import TELEGRAM_API_ID, TELEGRAM_API_HASH, BOT_TOKEN, LOG_LEVEL
+from logging_config import configure_logging
+from commands import register_handlers
+from task_queue import TaskQueue
+
+async def _run_workers(queue: TaskQueue) -> None:
+    """Background worker loop that processes tasks from *queue*.
+
+    The real implementation should spawn dedicated workers for download,
+    processing and uploading, possibly in separate processes. This stub simply
+    waits for tasks and logs them.
+    """
+    while True:
+        task = queue.get_task()
+        if task is None:
+            await asyncio.sleep(1)
+            continue
+        # TODO: dispatch task to the appropriate handler
+        print(f"processing task: {task.task_id}")
+
+async def main() -> None:
+    """Async entry point for running the bot."""
+    level = getattr(logging, LOG_LEVEL.upper(), logging.INFO)
+    configure_logging(level)
+    queue = TaskQueue()
+    client = TelegramClient("bot", TELEGRAM_API_ID, TELEGRAM_API_HASH)
+    await client.start(bot_token=BOT_TOKEN)
+    register_handlers(client, queue)
+    worker = asyncio.create_task(_run_workers(queue))
+    try:
+        await client.run_until_disconnected()
+    finally:
+        worker.cancel()
+        with contextlib.suppress(Exception):
+            await worker
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/monitor.py
+++ b/monitor.py
@@ -1,0 +1,21 @@
+"""Stream monitoring utilities.
+
+This module provides helpers for periodically checking whether a stream is
+online and triggering recording tasks. The actual recording is delegated to the
+:mod:`recorder` module or other workers.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable
+
+from config import MONITOR_POLL_INTERVAL
+
+__all__ = ["monitor_stream"]
+
+Callback = Callable[[str], Awaitable[None]]
+
+async def monitor_stream(url: str, on_online: Callback, poll_interval: int = MONITOR_POLL_INTERVAL) -> None:
+    """Periodically check *url* and call ``on_online(url)`` when it becomes available."""
+    # TODO: implement monitoring using yt-dlp or other method
+    raise NotImplementedError

--- a/processing.py
+++ b/processing.py
@@ -1,0 +1,54 @@
+"""Media processing helpers using ffmpeg.
+
+This module contains coroutine helpers that spawn ``ffmpeg`` subprocesses to
+perform operations like cutting, concatenation or transcoding. Each function is
+currently a stub and should be implemented with proper error handling and
+retries.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Iterable
+
+from config import FFMPEG_PATH
+
+__all__ = [
+    "cut_clip",
+    "concat_videos",
+    "transcode_video",
+    "normalize_audio",
+    "snapshot",
+]
+
+async def _run_ffmpeg(args: Iterable[str]) -> asyncio.subprocess.Process:
+    """Run ffmpeg with *args* and return the process handle."""
+    return await asyncio.create_subprocess_exec(
+        FFMPEG_PATH, *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+    )
+
+async def cut_clip(src: Path, dst: Path, start: str, end: str) -> Path:
+    """Cut a segment from *src* into *dst* using timestamps ``start`` and ``end``.
+    """
+    # TODO: implement ffmpeg slicing
+    raise NotImplementedError
+
+async def concat_videos(files: Iterable[Path], dst: Path) -> Path:
+    """Concatenate multiple video files into one."""
+    # TODO: implement ffmpeg concatenation
+    raise NotImplementedError
+
+async def transcode_video(src: Path, dst: Path, video_codec: str = "libx264", audio_codec: str = "aac") -> Path:
+    """Transcode *src* into *dst* with provided codecs."""
+    # TODO: implement ffmpeg transcoding
+    raise NotImplementedError
+
+async def normalize_audio(src: Path, dst: Path) -> Path:
+    """Normalize audio track loudness."""
+    # TODO: implement ffmpeg loudnorm
+    raise NotImplementedError
+
+async def snapshot(src: Path, dst: Path, at: str = "00:00:01") -> Path:
+    """Save a thumbnail image at timestamp ``at``."""
+    # TODO: implement snapshot generation
+    raise NotImplementedError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 telethon>=1.29.0
 yt-dlp>=2024.0.0
+pytest-asyncio>=0.23.0  # test dependency

--- a/task_queue.py
+++ b/task_queue.py
@@ -1,0 +1,38 @@
+"""Priority based task queue used by workers.
+
+This is a lightweight wrapper around :mod:`heapq` to manage asynchronous tasks
+with priorities. Each task is represented by the :class:`Task` dataclass.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import heapq
+from typing import Any, List, Optional
+
+__all__ = ["Task", "TaskQueue"]
+
+@dataclass(order=True)
+class Task:
+    """Representation of a unit of work."""
+    priority: int
+    task_id: str = field(compare=False)
+    data: Any = field(default_factory=dict, compare=False)
+
+class TaskQueue:
+    """Simple priority queue for tasks."""
+
+    def __init__(self) -> None:
+        self._queue: List[Task] = []
+
+    def add_task(self, task: Task) -> None:
+        """Push a new task onto the queue."""
+        heapq.heappush(self._queue, task)
+
+    def get_task(self) -> Optional[Task]:
+        """Pop the highest priority task or return ``None`` if empty."""
+        if not self._queue:
+            return None
+        return heapq.heappop(self._queue)
+
+    def __len__(self) -> int:
+        return len(self._queue)

--- a/upload.py
+++ b/upload.py
@@ -1,0 +1,39 @@
+"""High level upload helpers for Telegram.
+
+These functions handle auto-splitting of large files, retries with exponential
+backoff and resumable uploads. Real implementation will require persistent
+storage to track upload state.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, AsyncIterator, Optional
+
+from telethon import TelegramClient
+
+CHUNK_SIZE_LIMIT = 2 * 1024 * 1024 * 1024  # 2 GiB
+
+__all__ = ["upload_file", "iter_file_chunks"]
+
+async def iter_file_chunks(file_path: Path, chunk_size: int = CHUNK_SIZE_LIMIT) -> AsyncIterator[bytes]:
+    """Yield chunks from *file_path* for uploading.
+
+    This is a simplified stub. Real implementation should support resume by
+    remembering the last uploaded byte offset.
+    """
+    # TODO: implement chunk iterator
+    raise NotImplementedError
+
+async def upload_file(
+    client: TelegramClient,
+    file_path: Path,
+    target: int | str,
+    caption: Optional[str] = None,
+) -> None:
+    """Upload a local file to *target* using *client*.
+
+    The file will be split automatically if it exceeds Telegram limits. This
+    stub should be expanded with retry logic and progress reporting.
+    """
+    # TODO: implement segmented upload to Telegram
+    raise NotImplementedError


### PR DESCRIPTION
## Summary
- bootstrap Telethon bot entrypoint with worker loop and task queue
- stub out command handlers and media processing/download/upload helpers
- provide dataclass-based config, JSON logging, and filesystem utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0a3c8e2948332b7fb4a8420dc4cea